### PR TITLE
Start refactoring and enable code quality checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,35 @@
+repos:
+-   repo: meta
+    hooks:
+    -   id: check-useless-excludes
+
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+    -   id: check-added-large-files
+    -   id: check-case-conflict
+    -   id: check-executables-have-shebangs
+    -   id: check-json
+    -   id: check-merge-conflict
+    -   id: check-shebang-scripts-are-executable
+    -   id: check-symlinks
+    -   id: check-xml
+    -   id: check-yaml
+    -   id: debug-statements
+    -   id: destroyed-symlinks
+    -   id: end-of-file-fixer
+    -   id: fix-byte-order-marker
+    -   id: fix-encoding-pragma
+    -   id: trailing-whitespace
+
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.9.2
+    hooks:
+    -   id: flake8
+        additional_dependencies: [pep8-naming]
+        language_version: python3
+
+-   repo: https://github.com/mgedmin/check-manifest
+    rev: "0.47"
+    hooks:
+    -   id: check-manifest

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -17,7 +17,7 @@ the two main principles guiding its drafting:
       both authors and holders of the economic rights over software.
 
 The authors of the CeCILL-B (for Ce[a] C[nrs] I[nria] L[ogiciel] L[ibre])
-license are: 
+license are:
 
 Commissariat à l'Energie Atomique - CEA, a public scientific, technical
 and industrial research establishment, having its principal place of
@@ -403,8 +403,8 @@ rights set forth in Article 5).
 
 9.3 The Licensee acknowledges that the Software is supplied "as is" by
 the Licensor without any other express or tacit warranty, other than
-that provided for in Article 9.2 and, in particular, without any warranty 
-as to its commercial value, its secured, safe, innovative or relevant 
+that provided for in Article 9.2 and, in particular, without any warranty
+as to its commercial value, its secured, safe, innovative or relevant
 nature.
 
 Specifically, the Licensor does not warrant that the Software is free

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,8 @@ graft neurospin_to_bids/template_deface
 
 recursive-include tests *.py
 include tox.ini
+include .pre-commit-config.yaml
+exclude .deepsource.toml
 recursive-include requirements *.in
 recursive-include requirements *.sh
 recursive-include requirements *.txt

--- a/README.md
+++ b/README.md
@@ -33,18 +33,22 @@ cd neurospin_to_bids
 python3 -m venv venv/
 . venv/bin/activate
 pip install -c requirements/production.txt -c requirements/test.txt -e .[dev]
+
+# Please install pre-commit if you intend to contribute
+pre-commit install  # install the pre-commit hook
 ```
 
 Other commands that are useful for developers:
 ```
 # Tests. Always confirm that they succeed before committing. Please.
-pytest  # run tests in the current environment
 
-# Run tests in an isolated environment that closely approximates production
+# Run tests in an isolated environment that closely approximates
+# production, as well as code quality checks (recommended)
 tox
 
+pytest  # run tests in the current environment
+
 # Other commands useful for development
-check-manifest  # check that all necessary files are installed by pip
 ./requirements/update.sh  # upgrade pinned dependency versions
 
 # Ensure that only packages pinned for production are installed

--- a/neurospin_to_bids/dicom_database.py
+++ b/neurospin_to_bids/dicom_database.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+
+"""Tools for working with the NeuroSpin DICOM archive."""
+
+import os.path
+
+from .utils import UserError
+
+
+NEUROSPIN_DATABASES = {
+    'prisma': 'database/Prisma_fit',
+    'trio': 'database/TrioTim',
+    '7t': 'database/Investigational_Device_7T',
+    'meg': 'neuromag/data',
+}
+"""Path of each scanner's database relative to /neurospin/acquisition."""
+
+
+def get_database_path(scanner, acquisition_root_path='/neurospin/acquisition'):
+    """Get the full path to the database corresponding to the given scanner.
+
+    scanner (str): valid choices are the members of NEUROSPIN_DATABASES.keys()
+    acquisition_root_path (str): normally '/neurospin/acquisition', but could
+        be e.g. '/nfs/neurospin/acquisition' on a laptop.
+    """
+    try:
+        relative_db_path = NEUROSPIN_DATABASES[scanner.strip().lower()]
+    except KeyError:
+        raise UserError('invalid scanner {0!r}, must be one of {{{1}}}'
+                        .format(scanner,
+                                ', '.join(NEUROSPIN_DATABASES.keys())))
+    return os.path.join(acquisition_root_path, relative_db_path)
+
+
+# Characters that are replaced by '-' in filenames (see the pdsu.py script in
+# https://margaux.intra.cea.fr/redmine/projects/pdsu).
+# illegal characters, to be filtered out from filenames:
+# • Windows reserved characters
+# • '_' because it is reserved by Brainvisa
+# • spaces, tab, newline and null character
+FILENAME_ILLEGAL_CHARS = '\\/:*?"<>|_ \t\r\n\0'
+FILENAME_CLEANUP_TABLE = {ord(char): '-' for char in FILENAME_ILLEGAL_CHARS}

--- a/neurospin_to_bids/exp_info.py
+++ b/neurospin_to_bids/exp_info.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+"""Code related to the exp_info directory (inputs of neurospin-to-bids)"""
+
+import os
+
+import pandas as pd
+
+
+def read_participants_to_import(exp_info_path, filename=None):
+    """Load participants_to_import.tsv as a Pandas dataframe.
+
+    - exp_info_path (str) is the path to the exp_info directory which normally
+    contains participants_to_import.tsv
+
+    - filename (str or None) is the name of the participants_to_import.tsv
+    file. In the normal case this is None, and the two names are used by
+    decreasing of priority: 'participants_to_import.tsv' or 'participants.tsv'
+    (the old, deprecated name for that file).
+    """
+    if not os.path.exists(exp_info_path):
+        raise Exception('exp_info directory not found')
+    if os.path.isfile(os.path.join(exp_info_path,
+                                   'participants_to_import.tsv')):
+        participants_to_import = os.path.join(exp_info_path,
+                                              'participants_to_import.tsv')
+    elif os.path.isfile(os.path.join(exp_info_path, 'participants.tsv')):
+        # Legacy name of participants_to_import.tsv
+        participants_to_import = os.path.join(exp_info_path,
+                                              'participants.tsv')
+    else:
+        raise Exception('exp_info/participants_to_import.tsv not found')
+    return pd.read_csv(participants_to_import,
+                       dtype=str,
+                       sep='\t',
+                       na_filter=False,
+                       index_col=False)

--- a/neurospin_to_bids/utils.py
+++ b/neurospin_to_bids/utils.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+"""Miscellaneous utility code."""
+
+
+class UserError(Exception):
+    """Exception for a user error, contains a message describing the error."""
+    pass

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,9 +28,7 @@ install_requires =
 
 [options.extras_require]
 dev =
-    check-manifest
-    flake8
-    pep8-naming
+    pre-commit
     pip-tools
     pytest
     tox

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # All build configuration is contained in setup.cfg.
 #
 # This file is present for compatibility with legacy builds (i.e. those not

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import distutils.spawn
 import subprocess
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py36
+envlist = py36, codestyle
 
 [testenv]
 deps = pip-tools
@@ -18,3 +18,24 @@ install_command = python -m pip install \
 commands_pre =
     python -m piptools sync requirements/production.txt requirements/test.txt
 commands = pytest {posargs}
+
+[testenv:codestyle]
+# pre-commit needs to clone Git repositories over https
+passenv = http_proxy https_proxy no_proxy
+commands_pre =  # do not inherit the piptools command
+commands = pre-commit run --all-files
+deps =
+    pre-commit
+
+[flake8]
+ignore =
+    # E203 (whitespace before ':') has false positive for array slicings
+    E203,
+    # these are on the default ignore list
+    E121, E126, E226, E133, E203, E241,
+    # We want line-break *before* the operator (new PEP8 style similar to math)
+    W503,
+    # Gives false positives when a name contains an uppercase acronym
+    N802,
+    # Temporary TODO(ylep): fix line lengths in __main__.py
+    E501


### PR DESCRIPTION
I have started to separate the code in several modules, because I am working on a mechanism to automate the discovery of acquisitions/series to import for each session, based on the DICOM `SeriesDescription` field, in the spirit of what [dcm2bids](https://github.com/UNFmontreal/Dcm2Bids) does.