### PR TITLE
Redundant wheel in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,3 @@
 [build-system]
-requires = [
-    "setuptools>=42",
-    "wheel"
-]
+requires = ["setuptools>=42"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
The backend adds the wheel dependency automatically:
> The `setuptools` package implements the `build_sdist` command and the `wheel` package implements the `build_wheel` command; the latter is a dependency of the former exposed via [**PEP 517**](https://peps.python.org/pep-0517/) hooks.

Listing it explicitly in the documentation was a historical mistake and has been fixed since in pypa/setuptools@f7d30a9.