### PR TITLE
Test recent versions of Python too

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - 3.6
+          - "3.6"
+          - "3.10"
+          - "3.11"
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
* 3.10 is the default in upcoming Ubuntu 22.04 workstations
* 3.11 is the latest release of Python