### PR TITLE
Apply ruff/flake8-implicit-str-concat rule ISC001

### DIFF
--- a/src/neurospin_to_bids/utils.py
+++ b/src/neurospin_to_bids/utils.py
@@ -97,4 +97,4 @@ def yes_no(question: str, *, default=None, noninteractive=None) -> bool:
             return valid[default]
         if choice in valid:
             return valid[choice]
-        print("Please respond with 'yes' or 'no' " "(or 'y' or 'n').\n")
+        print("Please respond with 'yes' or 'no' (or 'y' or 'n').\n")


### PR DESCRIPTION
	ISC001 Implicitly concatenated string literals on one line

This rule is currently disabled because it conflicts with the formatter:
	https://github.com/astral-sh/ruff/issues/8272