### PR TITLE
Ubuntu 20 image is closing down

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             python-version: '3.8'
           - os: ubuntu-22.04
             python-version: '3.10'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "pydicom",
     "setuptools",  # actually a dependency of pydeface (for pkg_resources)
 ]
-requires-python = "~=3.8"
+requires-python = ">=3.8"
 readme = "README.md"
 classifiers = [
     "License :: CeCILL-B Free Software License Agreement (CECILL-B)",
@@ -107,4 +107,4 @@ exclude_also = [
 
     # Don't complain about abstract methods, they aren't run:
     "@(abc\\.)?abstractmethod",
-    ]
+]


### PR DESCRIPTION
Actually it closed down on 15 April 2025. GitHub switched to Ubuntu 24.04 to test Python 3.8, let's use Ubuntu 22.04 instead.

https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/