### PR TITLE
PEP 639 compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.3"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -21,8 +21,9 @@ dependencies = [
 ]
 requires-python = ">=3.10"
 readme = "README.md"
+license = "CECILL-B"
+license-files = ["LICENSE.txt"]
 classifiers = [
-    "License :: CeCILL-B Free Software License Agreement (CECILL-B)",
     "Environment :: Console",
     "Intended Audience :: Science/Research",
     "Operating System :: POSIX",


### PR DESCRIPTION
Requires setuptools 77.0.3 which requires Python 3.9.

Don't merge until we drop support for Ubuntu 20.04 / Python 3.8.