### PR TITLE
Make pip-tools work again

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ Issues = "https://github.com/neurospin/neurospin_to_bids/issues"
 
 [dependency-groups]
 dev = [
-    "pip-tools",
+    "pip-tools<7.6",
     "pre-commit",
     "pytest",
     "pytest-cov",

--- a/tox.ini
+++ b/tox.ini
@@ -29,9 +29,11 @@ deps =
 # Passing multiple commands as part of install_command does not seem to work,
 # neither does substitution of {opts} and {packages}, so I had to resort to an
 # ugly hack using sh -c... (YL 2025-03-05 using tox 4.24.1)
+# - pip 26 currently breaks even the most recent versions of pip-tools
+# - pip-tools 7.6 doesn't work for us
 allowlist_externals = sh
 install_command =
-    sh -c 'python -I -m pip install -U pip pip-tools && python -m piptools sync requirements/py{py_dot_ver}-production.txt requirements/py{py_dot_ver}-test.txt && python -I -m pip install "$@"' -
+    sh -c 'python -I -m pip install -U "pip<26" "pip-tools<7.6" && python -m piptools sync requirements/py{py_dot_ver}-production.txt requirements/py{py_dot_ver}-test.txt && python -I -m pip install "$@"' -
 commands = pytest {posargs}
 
 


### PR DESCRIPTION
It looks like pip-tools fails to run with recent versions of pip:
```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "neurospin_to_bids/.tox/py312/lib/python3.12/site-packages/piptools/__main__.py", line 5, in <module>
    from piptools.scripts import compile, sync
  File "neurospin_to_bids/.tox/py312/lib/python3.12/site-packages/piptools/scripts/sync.py", line 17, in <module>
    from .. import sync
  File "neurospin_to_bids/.tox/py312/lib/python3.12/site-packages/piptools/sync.py", line 13, in <module>
    from pip._internal.utils.compat import stdlib_pkgs
ImportError: cannot import name 'stdlib_pkgs' from 'pip._internal.utils.compat' (neurospin_to_bids/.tox/py312/lib/python3.12/site-packages/pip/_internal/utils/compat.py)
```